### PR TITLE
Fix validation for unclean input

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -52,3 +52,13 @@ def test_age():
 def test_birthdate():
     birthdate = SouthAfricanIdentityValidate("9902204720082").birthdate()
     assert birthdate == datetime.strptime("99-02-20", "%y-%m-%d")
+
+
+def test_all_zeroes():
+    valid = SouthAfricanIdentityValidate("0000000000000").validate()
+    assert not valid
+
+
+def test_alphabetical():
+    valid = SouthAfricanIdentityValidate("123456ABC7890").validate()
+    assert not valid

--- a/za_id_number/za_id_number.py
+++ b/za_id_number/za_id_number.py
@@ -9,7 +9,10 @@ class SouthAfricanIdentityValidate(object):
 
     def validate(self):
         if self.identity_length():
-            return SouthAfricanIdentityNumber(self.id_number).valid
+            try:
+                return SouthAfricanIdentityNumber(self.id_number).valid
+            except ValueError:
+                return False
         else:
             return False
 


### PR DESCRIPTION
I had issues with junk input, as per issue #4

I also considered catching the ValueError in SouthAfricanIdentityNumber's constructor, but then you will have to generate a junk birthdate. So I thought it's best if that constructor still fails, which means that SouthAfricanIdentityValidate's age() and birthdate() will also raise a ValueError.